### PR TITLE
feat(frontend): add eslint-plugin-depend

### DIFF
--- a/frontend/eslint.config.mjs
+++ b/frontend/eslint.config.mjs
@@ -1,8 +1,9 @@
 import eslint from "@eslint/js";
+import { defineConfig } from "eslint/config";
+import depend from "eslint-plugin-depend";
 import eslintPluginPrettierRecommended from "eslint-plugin-prettier/recommended";
 import simpleImportSort from "eslint-plugin-simple-import-sort";
 import tseslint from "typescript-eslint";
-import { defineConfig } from "eslint/config";
 
 export default defineConfig(
   eslint.configs.recommended,
@@ -12,6 +13,7 @@ export default defineConfig(
   {
     plugins: {
       "simple-import-sort": simpleImportSort,
+      depend,
     },
     rules: {
       "prettier/prettier": "warn",
@@ -19,5 +21,6 @@ export default defineConfig(
       "simple-import-sort/exports": "error",
       "@typescript-eslint/consistent-type-definitions": ["error", "type"],
     },
+    extends: ["depend/flat/recommended"],
   },
 );

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -40,6 +40,7 @@
     "cypress-html-validate": "^8.1.0",
     "eslint": "^9.39.1",
     "eslint-config-prettier": "^10.1.8",
+    "eslint-plugin-depend": "^1.5.0",
     "eslint-plugin-prettier": "^5.5.5",
     "eslint-plugin-simple-import-sort": "^12.1.1",
     "html-validate": "^10.9.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -10158,6 +10158,19 @@ __metadata:
   languageName: node
   linkType: hard
 
+"eslint-plugin-depend@npm:^1.5.0":
+  version: 1.5.0
+  resolution: "eslint-plugin-depend@npm:1.5.0"
+  dependencies:
+    empathic: "npm:^2.0.0"
+    module-replacements: "npm:^2.10.1"
+    semver: "npm:^7.6.3"
+  peerDependencies:
+    eslint: ">=8.40.0"
+  checksum: 10c0/8b94d9087ff4ebc72d848739e53635c2e9e6e7b9fcc0714fe06ac4ccbcc73a87295294409fed69758cc373fc8ebce29a7f71969026e686177cb49c2dace3df90
+  languageName: node
+  linkType: hard
+
 "eslint-plugin-flowtype@npm:^5.10.0":
   version: 5.10.0
   resolution: "eslint-plugin-flowtype@npm:5.10.0"
@@ -11404,6 +11417,7 @@ __metadata:
     cypress-html-validate: "npm:^8.1.0"
     eslint: "npm:^9.39.1"
     eslint-config-prettier: "npm:^10.1.8"
+    eslint-plugin-depend: "npm:^1.5.0"
     eslint-plugin-prettier: "npm:^5.5.5"
     eslint-plugin-simple-import-sort: "npm:^12.1.1"
     gatsby: "npm:^5.16.1"
@@ -15321,6 +15335,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"module-replacements@npm:^2.10.1":
+  version: 2.11.0
+  resolution: "module-replacements@npm:2.11.0"
+  checksum: 10c0/c5bdd8eb53378c00f302863bae07399f31364a814e339f04a4d740e8c13b467a255c9c51a6cf155b80b390408385540019d764ff6c9606736ece2f64126e3e72
+  languageName: node
+  linkType: hard
+
 "moment@npm:^2.29.4":
   version: 2.30.1
   resolution: "moment@npm:2.30.1"
@@ -18703,12 +18724,12 @@ __metadata:
   languageName: node
   linkType: hard
 
-"semver@npm:^7.0.0, semver@npm:^7.2.1, semver@npm:^7.3.2, semver@npm:^7.3.4, semver@npm:^7.3.5, semver@npm:^7.3.7, semver@npm:^7.3.8, semver@npm:^7.5.3, semver@npm:^7.5.4, semver@npm:^7.7.2, semver@npm:^7.7.3":
-  version: 7.7.4
-  resolution: "semver@npm:7.7.4"
+"semver@npm:^7.0.0, semver@npm:^7.2.1, semver@npm:^7.3.2, semver@npm:^7.3.4, semver@npm:^7.3.5, semver@npm:^7.3.7, semver@npm:^7.3.8, semver@npm:^7.5.3, semver@npm:^7.5.4, semver@npm:^7.6.3, semver@npm:^7.7.2, semver@npm:^7.7.3":
+  version: 7.8.1
+  resolution: "semver@npm:7.8.1"
   bin:
     semver: bin/semver.js
-  checksum: 10c0/5215ad0234e2845d4ea5bb9d836d42b03499546ddafb12075566899fc617f68794bb6f146076b6881d755de17d6c6cc73372555879ec7dce2c2feee947866ad2
+  checksum: 10c0/92d6871d6347e1f99d0ba396a70f2545ccf2a032cda3d378fa0699edf7506b5c6d266aed55c8b88e72bd91a30d2351e4f39db479375374430fcdc4b58f4e3c1a
   languageName: node
   linkType: hard
 


### PR DESCRIPTION
Adds `eslint-plugin-depend` to the frontend ESLint config.

The plugin flags imports of packages that have native JS equivalents or better alternatives (e.g. `lodash`, `moment`, `uuid`, polyfills, micro-utilities).

## Changes
- `frontend/eslint.config.mjs` — register `depend` plugin and extend `depend/flat/recommended`; sort imports alphabetically
- `frontend/package.json` — add `eslint-plugin-depend@^1.5.0`
- `yarn.lock` — add `eslint-plugin-depend`, `module-replacements`; bump `semver` to `7.8.1`