### PR TITLE
Add npmMinimalAgeGate: "3d"

### DIFF
--- a/.yarnrc.yml
+++ b/.yarnrc.yml
@@ -5,3 +5,5 @@ enableGlobalCache: true
 logFilters:
   - code: YN0002 # https://yarnpkg.com/advanced/error-codes#yn0002---missing_peer_dependency
     level: error
+
+npmMinimalAgeGate: "3d"


### PR DESCRIPTION
Adds `npmMinimalAgeGate: "3d"` to `.yarnrc.yml` to prevent Yarn from installing npm packages that were published less than 3 days ago, reducing the risk of installing malicious or unstable packages that may have just been published.